### PR TITLE
cmake: rename BUILD_YOCTO to USE_SYSTEM_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG   ${CMAKE_CURRENT_SOURCE_DIR}/export)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_SOURCE_DIR}/export)
 
 option(BUILD_TESTS              "Build CMocka unit tests"              OFF)
-option(BUILD_YOCTO              "Build in a Yocto build environment"   OFF)
+option(USE_SYSTEM_LIBS          "Use system-provided libraries"        OFF)
 option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer (Clang)"     OFF)
 option(ENABLE_VALGRIND_SUPPORT  "Build with Valgrind support"          OFF)
 
@@ -134,7 +134,7 @@ add_dependencies(
   core
 )
 
-if(NOT BUILD_YOCTO)
+if(NOT USE_SYSTEM_LIBS)
   add_dependencies(
     core
     ${PLATFORM_CORE_DEPS})

--- a/cmake/codb2json.cmake
+++ b/cmake/codb2json.cmake
@@ -15,7 +15,7 @@ target_link_libraries(
   ${PLATFORM_LIBS}
 )
 
-if(NOT BUILD_YOCTO)
+if(NOT USE_SYSTEM_LIBS)
   add_dependencies(
     codb2json
     cJSON_devel

--- a/cmake/os_linux.cmake
+++ b/cmake/os_linux.cmake
@@ -35,8 +35,8 @@ if(BUILD_TESTS)
   )
 endif(BUILD_TESTS)
 
-# Use system dependencies when building in a Yocto environment.
-if (BUILD_YOCTO)
+# Use system-provided libraries instead of fetching them at build time.
+if (USE_SYSTEM_LIBS)
   find_package(SDL3 REQUIRED)
   if (SDL3_FOUND)
     include_directories(${SDL3_INCLUDE_DIRS})

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,3 +93,10 @@ cd build
 cmake ..
 make
 ```
+
+### System Libraries
+
+When system-provided libraries are available (e.g. via a distribution
+package manager or an embedded Linux build system), pass
+`-DUSE_SYSTEM_LIBS=ON` to CMake to skip fetching dependencies at build
+time and link against the installed libraries instead.


### PR DESCRIPTION
Replace the Yocto-specific BUILD_YOCTO option with a more generic USE_SYSTEM_LIBS flag to better reflect its purpose: skipping the automatic fetching of dependencies at build time and using libraries already provided by the host system instead.

This allows the same flag to be used in any environment where system libraries are available.