### PR TITLE
Remove usage of white text-color

### DIFF
--- a/src/core/can.c
+++ b/src/core/can.c
@@ -120,7 +120,7 @@ void can_flush(void)
 status_t can_print_baud_rate_help(core_t* core)
 {
     status_t status;
-    table_t table = {DARK_CYAN, DARK_WHITE, 3, 13, 6};
+    table_t table = {DARK_CYAN, DEFAULT_COLOR, 3, 13, 6};
     char br_status[15][7] = {0};
     unsigned int br_status_index = core->baud_rate;
     unsigned int index;
@@ -170,7 +170,7 @@ status_t can_print_baud_rate_help(core_t* core)
 status_t can_print_channel_help(core_t* core)
 {
     status_t status = ALL_OK;
-    table_t table = {DARK_CYAN, DARK_WHITE, 3, 48, 6};
+    table_t table = {DARK_CYAN, DEFAULT_COLOR, 3, 48, 6};
     char ch_status[33][7] = {0};
     unsigned int ch_status_index = core->can_channel;
     unsigned int ch_count = 0;

--- a/src/core/command.c
+++ b/src/core/command.c
@@ -450,7 +450,7 @@ static void convert_token_to_uint64(char* token, uint64* result)
 status_t print_usage_information(bool show_all)
 {
     status_t status;
-    table_t table = {DARK_CYAN, DARK_WHITE, 3, 45, 17};
+    table_t table = {DARK_CYAN, DEFAULT_COLOR, 3, 45, 17};
 
     status = table_init(&table, 1024);
     table_print_header(&table);

--- a/src/core/common.c
+++ b/src/core/common.c
@@ -18,7 +18,7 @@ void list_file_type(const char* dir, const char* ext, uint32 active_no)
     const char* data_path = os_find_data_path();
     char file_path[512] = {0};
     DIR_t* d;
-    table_t table = {DARK_CYAN, DARK_WHITE, 3, 25, 1};
+    table_t table = {DARK_CYAN, DEFAULT_COLOR, 3, 25, 1};
     status_t status;
     uint32 status_width = 1;
 

--- a/src/core/nmt.c
+++ b/src/core/nmt.c
@@ -104,7 +104,7 @@ status_t nmt_print_help(disp_mode_t disp_mode)
     }
     else
     {
-        table_t table = {DARK_CYAN, DARK_WHITE, 4, 5, 30};
+        table_t table = {DARK_CYAN, DEFAULT_COLOR, 4, 5, 30};
 
         status = table_init(&table, 1024);
         if (ALL_OK == status)

--- a/src/core/pdo.c
+++ b/src/core/pdo.c
@@ -106,7 +106,7 @@ static uint64 pdo_send_callback(void* pdo_pt, uint32 id, uint64 interval)
 status_t pdo_print_help(void)
 {
     status_t status;
-    table_t table = {DARK_CYAN, DARK_WHITE, 13, 7, 7};
+    table_t table = {DARK_CYAN, DEFAULT_COLOR, 13, 7, 7};
 
     status = table_init(&table, 1024);
     if (ALL_OK == status)

--- a/src/core/scripts.c
+++ b/src/core/scripts.c
@@ -187,7 +187,7 @@ bool has_valid_extension(const char* filename)
 status_t list_scripts(void)
 {
     status_t status;
-    table_t table = {DARK_CYAN, DARK_WHITE, 3, 10, 40};
+    table_t table = {DARK_CYAN, DEFAULT_COLOR, 3, 10, 40};
 
 #ifdef _WIN32
     init_script_search_paths();

--- a/src/os/os_linux.c
+++ b/src/os/os_linux.c
@@ -200,7 +200,7 @@ void os_log(const log_level_t level, const char* format, ...)
         case LOG_DEFAULT:
             break;
         case LOG_INFO:
-            os_print(DARK_WHITE, "[INFO]    ");
+            os_print(DEFAULT_COLOR, "[INFO]    ");
             break;
         case LOG_SUCCESS:
             os_print(LIGHT_GREEN, "[SUCCESS] ");

--- a/src/os/os_windows.c
+++ b/src/os/os_windows.c
@@ -248,7 +248,7 @@ void os_log(const log_level_t level, const char* format, ...)
         case LOG_DEFAULT:
             break;
         case LOG_INFO:
-            os_print(DARK_WHITE, "[INFO]    ");
+            os_print(DEFAULT_COLOR, "[INFO]    ");
             break;
         case LOG_SUCCESS:
             os_print(LIGHT_GREEN, "[SUCCESS] ");


### PR DESCRIPTION
In a black-on-white terminal (or generally: any terminal with a white background color), white text is unreadable. So instead of maybe highlighting on dark background by printing it in white, default all such text to the default-color, which should work for both black-on-white and white-on-black terminals.

This mostly affects the contents of tables, but also the severity-label of log-messages of severity INFO.

Fixes #112